### PR TITLE
Add 'encoding' parameter in open function for Windows.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 import os
+from codecs import open
 from setuptools import setup, find_packages
 
 app_name = 'doco'

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ app_name = 'doco'
 
 rst = os.path.join(os.path.dirname(__file__), 'README.rst')
 description = ''
-with open(rst, 'r') as f:
+with open(rst, 'r', encoding='utf8') as f:
     description = f.read()
 
 setup(


### PR DESCRIPTION
Windows環境でpip install docoとすると下記エラーが発生するため、エラー箇所のopen関数にエンコーディング指定を追加しました。
UnicodeDecodeError: 'cp932' codec can't decode byte 0x83 in position 479: illegal multibyte sequence

以下環境でpython setup.py installが成功することを確認しました。
Windows10(64bit) + python3.6.3
macOS High Sierra + python3.6.3